### PR TITLE
Remove deprecated stuff from *.gemspec

### DIFF
--- a/kyotocabinet.gemspec
+++ b/kyotocabinet.gemspec
@@ -12,8 +12,3 @@ spec = Gem::Specification.new do |s|
   s.require_path = "."
   s.extensions = [ "extconf.rb" ]
 end
-
-if $0 == __FILE__
-  Gem::manage_gems
-  Gem::Builder.new(spec).build
-end


### PR DESCRIPTION
1. `Gem::manage_gems` is deprecated
2. No need to call `Gem::Builder` from `gemspec` because `gem build` just works
3. `gemspec` code is responsible for returning `Gem::Specification` instance but all this code after gemspec definition just heads this off.
