### PR TITLE
Fix GVL issues

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -26,5 +26,6 @@ printf("  \$LDFLAGS = %s\n", $LDFLAGS)
 printf("  \$libs = %s\n", $libs)
 
 if have_header('kccommon.h')
+  have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
   create_makefile('kyotocabinet')
 end

--- a/kyotocabinet.cc
+++ b/kyotocabinet.cc
@@ -20,6 +20,9 @@ namespace kc = kyotocabinet;
 extern "C" {
 
 #include <ruby.h>
+#ifdef HAVE_RUBY_THREAD_H
+#include <ruby/thread.h>
+#endif
 
 #if RUBY_VM >= 1
 #define _KC_YARV_
@@ -599,16 +602,20 @@ class NativeFunction {
   virtual void operate() = 0;
   static void execute(NativeFunction* func) {
 #if defined(_KC_YARV_)
-    rb_thread_blocking_region(execute_impl, func, RUBY_UBF_IO, NULL);
+#ifdef HAVE_RB_THREAD_CALL_WITHOUT_GVL
+    rb_thread_call_without_gvl(execute_impl, func, RUBY_UBF_IO, NULL);
+#else
+    rb_thread_blocking_region((rb_blocking_function_t *)execute_impl, func, RUBY_UBF_IO, NULL);
+#endif
 #else
     func->operate();
 #endif
   }
  private:
-  static VALUE execute_impl(void* ptr) {
+  static void* execute_impl(void* ptr) {
     NativeFunction* func = (NativeFunction*)ptr;
     func->operate();
-    return Qnil;
+    return NULL;
   }
 };
 


### PR DESCRIPTION
1. `rb_thread_blocking_region` is now deprecated in favor of `rb_thread_call_without_gvl` in Ruby 2.
2. But there is no `rb_thread_call_without_gvl` in Ruby 1.9

So I suggest this workaround
